### PR TITLE
Upgrade to ember-cli-sass 5.4.0

### DIFF
--- a/blueprints/ember-materialize-shim/files/ember-cli-build.js
+++ b/blueprints/ember-materialize-shim/files/ember-cli-build.js
@@ -1,7 +1,6 @@
 /*jshint node:true*/
 /* global require, module */
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
-var nodeSass = require('node-sass'); // loads the version in your package.json
 
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
@@ -9,8 +8,7 @@ module.exports = function(defaults) {
     sassOptions: {
       includePaths: [
         'bower_components/materialize/sass'
-      ],
-      nodeSass: nodeSass // Workaround for ember-cli-sass bug https://github.com/aexmachina/ember-cli-sass/issues/117
+      ]
     }
   });
 

--- a/blueprints/ember-materialize-shim/index.js
+++ b/blueprints/ember-materialize-shim/index.js
@@ -8,14 +8,12 @@ module.exports = {
       return this.addAddonsToProject({
         packages: [{
           name: 'ember-cli-sass',
-          target: '~5.3.0'
+          target: '~5.4.0'
         }, {
           name: 'ember-material-design-icons-shim',
           target: '~0.1.9'
         }]
-      }).then(function() {
-        return this.addPackageToProject('node-sass@~3.4.0');
-      }.bind(this));
+      });
     }.bind(this));
   }
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,14 +1,12 @@
 /*jshint node:true*/
 /* global require, module */
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
-var nodeSass = require('node-sass'); // loads the version in your package.json
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     sassOptions: {
       includePaths: [
         'bower_components/materialize/sass'
-      ],
-      nodeSass: nodeSass
+      ]
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ember-cli-jshint": "^1.0.3",
     "ember-cli-qunit": "^2.0.0",
     "ember-cli-release": "1.0.0-beta.1",
+    "ember-cli-sass": "^5.4.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
@@ -39,7 +40,6 @@
     "ember-suave": "4.0.0",
     "ember-sublime": "0.0.9",
     "loader.js": "^4.0.1",
-    "node-sass": "3.4.2",
     "os-locale": "^1.4.0",
     "y18n": "^3.2.1"
   },
@@ -57,7 +57,6 @@
     "android"
   ],
   "dependencies": {
-    "ember-cli-sass": "5.3.1",
     "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {


### PR DESCRIPTION
ember-cli-sass 5.4.0 contains a fix for a seg fault that was occuring in certain versions of node sass.  As a result, this commit removes the custom node-sass version from the default blueprint.

CHANGES:

- Upgrade ember-cli-sass in blueprint and package.json
- Move ember-cli-sass to devDependencies in package.json
- Remove custom node-sass from default blueprint